### PR TITLE
fix: Rename skipPatterns to skip_patterns in JoinConvoAIReq for consistency with JSON property naming conventions

### DIFF
--- a/agora-rest-client-core/src/main/java/io/agora/rest/services/convoai/req/JoinConvoAIReq.java
+++ b/agora-rest-client-core/src/main/java/io/agora/rest/services/convoai/req/JoinConvoAIReq.java
@@ -870,7 +870,7 @@ public class JoinConvoAIReq {
          * <p>
          * 5: Skip content in curly braces { }
          */
-        @JsonProperty("skipPatterns")
+        @JsonProperty("skip_patterns")
         private List<Integer> skipPatterns;
 
         public static Builder builder() {


### PR DESCRIPTION
fix: Rename skipPatterns to skip_patterns in JoinConvoAIReq for consistency with JSON property naming conventions